### PR TITLE
Added Firebase Hosting Rewrites

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -5,6 +5,12 @@
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
     ]
   },
   "firestore": {


### PR DESCRIPTION
The links to the main website doesn't seem to be redirecting properly to Firebase as a result of which "Site Not Found" error occurs, this was due to the rewrites not pointing to `index.html` file. This should fix that problem.